### PR TITLE
Feature: Add `locale` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,17 @@ export default {
 </script>
 ```
 
+#### Changing Locale (v2.3.3+)
+`paypal-checkout` allows changing the locale of the button via a `locale` parameter. There's a `locale` prop you can use to accomplish the same:
+
+``` html
+ <PayPal
+  amount="10.00"
+  currency="USD"
+  locale="en_US"
+  :client="credentials">
+</PayPal>
+```
 #### Button Style
 `paypal-checkout` allows changing the style of the button via a style object like so:
 

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -21,8 +21,8 @@
       <paypal-checkout
         amount="10.00"
         currency="USD"
+        env="sandbox"
         :client="paypal"
-        :dev="true"
         :invoice-number="'201705051001'">
       </paypal-checkout>
     </div>

--- a/examples/braintree.html
+++ b/examples/braintree.html
@@ -21,10 +21,10 @@
     <div class="content">
       <p>Pay with USD $10.00</p>
       <paypal-checkout
+        env="sandbox"
         amount="10.00"
         currency="USD"
         :client="paypal"
-        :dev="true"
         :invoice-number="'201705051001'"
         :braintree="paypal.braintree">
       </paypal-checkout>

--- a/examples/experience.html
+++ b/examples/experience.html
@@ -19,10 +19,10 @@
     <div class="content">
       <p>Pay with USD $10.00</p>
       <paypal-checkout
+        env="sandbox"
         amount="10.00"
         currency="USD"
         :client="paypal"
-        :dev="true"
         :invoice-number="'201705051001'"
         :experience="experience">
       </paypal-checkout>

--- a/examples/locale.html
+++ b/examples/locale.html
@@ -13,7 +13,7 @@
 
 <body>
   <script src="https://unpkg.com/vue@^2.5/dist/vue.js"></script>
-  <script src="https://unpkg.com/vue-paypal-checkout/dist/vue-paypal-checkout.min.js"></script>
+  <script src="../dist/vue-paypal-checkout.min.js"></script>
 
   <div id="app">
     <div class="content">
@@ -22,8 +22,8 @@
         env="sandbox"
         amount="10.00"
         currency="USD"
+        locale="fr_FR"
         :client="paypal"
-        :button-style="aStyle"
         :invoice-number="'201705051001'">
       </paypal-checkout>
     </div>
@@ -38,12 +38,6 @@
           paypal: {
             sandbox: 'Ad1voWYq3VL8J4jy6zWARKwz4tjbuDl_TFBa3WQqy_DwAFWd7hkU4i99jijGqaoqU3E-ODqXDayVnOdl',
             production: '',
-          },
-          aStyle: {
-            label: 'pay',
-            size: 'small',
-            shape: 'rect',
-            color: 'blue',
           },
         };
       },

--- a/src/additionalProps.js
+++ b/src/additionalProps.js
@@ -3,6 +3,7 @@ import PayPalProp, { propTypes } from './util/paypalProp';
 const props = [
   new PayPalProp({ name: 'buttonStyle', paypalName: 'style', type: propTypes.BUTTON }),
   new PayPalProp({ name: 'braintree', type: propTypes.BUTTON }),
+  new PayPalProp({ name: 'locale', type: propTypes.BUTTON }),
 ];
 
 function vmProps() {

--- a/src/components/PayPalCheckout.vue
+++ b/src/components/PayPalCheckout.vue
@@ -83,7 +83,7 @@ export default {
     additionalProps.getTypedProps(propTypes.BUTTON).forEach((prop) => {
       const result = prop.getChange(vue);
 
-      if (result !== undefined) {
+      if (result !== undefined && result !== null) {
         const { name, value } = result;
         button[name] = value;
       }

--- a/src/util/defaultProps.js
+++ b/src/util/defaultProps.js
@@ -25,6 +25,7 @@ const specificProps = [
   // eslint-disable-next-line
   { name: 'commit', type: Boolean, required: false, default: true },
   { name: 'items', type: Array, required: false },
+  { name: 'locale', type: String, required: false },
   { name: 'buttonStyle', type: Object, required: false },
   { name: 'experience', type: Object, required: false },
 ];

--- a/test/unit/specs/util/defaultProps.spec.js
+++ b/test/unit/specs/util/defaultProps.spec.js
@@ -73,6 +73,11 @@ describe('defaultProps.js', () => {
       required: false,
     });
 
+    expect(props.locale).toEqual({
+      type: String,
+      required: false,
+    });
+
     expect(props.buttonStyle).toEqual({
       type: Object,
       required: false,


### PR DESCRIPTION
Turns out there's a very useful `locale` configurable parameter `paypal-checkout` allows you to set for changing the locale/language of the button.

Fixes #14.