### PR TITLE
Fix Prop Validation

### DIFF
--- a/src/additionalProps.js
+++ b/src/additionalProps.js
@@ -1,9 +1,9 @@
 import PayPalProp, { propTypes } from './util/paypalProp';
 
 const props = [
-  new PayPalProp({ name: 'buttonStyle', paypalName: 'style', type: propTypes.BUTTON }),
-  new PayPalProp({ name: 'braintree', type: propTypes.BUTTON }),
-  new PayPalProp({ name: 'locale', type: propTypes.BUTTON }),
+  new PayPalProp({ name: 'buttonStyle', paypalName: 'style', injection: propTypes.BUTTON }),
+  new PayPalProp({ name: 'braintree', injection: propTypes.BUTTON }),
+  new PayPalProp({ name: 'locale', type: String, injection: propTypes.BUTTON }),
 ];
 
 function vmProps() {

--- a/src/util/defaultProps.js
+++ b/src/util/defaultProps.js
@@ -25,8 +25,6 @@ const specificProps = [
   // eslint-disable-next-line
   { name: 'commit', type: Boolean, required: false, default: true },
   { name: 'items', type: Array, required: false },
-  { name: 'locale', type: String, required: false },
-  { name: 'buttonStyle', type: Object, required: false },
   { name: 'experience', type: Object, required: false },
 ];
 

--- a/src/util/paypalProp.js
+++ b/src/util/paypalProp.js
@@ -1,23 +1,29 @@
 function paypalProp(prop) {
-  this.name = prop.name;
+  /* eslint-disable no-param-reassign */
+  const define = (function getDefine(object) {
+    return function def(name, param, defaultParam) {
+      const isDefined = typeof param !== 'undefined'
+        && param !== null;
+      const hasDefault = typeof defaultParam !== 'undefined'
+        && defaultParam !== null;
 
-  if (typeof prop.paypalName !== 'undefined') {
-    this.propName = prop.paypalName;
-  } else {
-    this.propName = this.name;
-  }
+      if (isDefined) object[name] = param;
+      else if (hasDefault) object[name] = defaultParam;
+      else object[name] = null; // TODO: throw err?
+    };
+  }(this));
 
-  if (typeof prop.injectionType !== 'undefined') {
-    this.injection = prop.injectionType;
-  } else {
-    this.injection = 'button';
-  }
+  define('name', prop.name);
+  define('propName', prop.paypalName, prop.name);
+  define('injection', prop.injection, 'button');
+  define('type', prop.type, Object);
+  define('required', prop.required, false);
 }
 
 paypalProp.prototype.getVmProp = function getVmProp() {
   return {
-    type: Object,
-    required: false,
+    type: this.type,
+    required: this.required,
   };
 };
 

--- a/test/unit/specs/util/defaultProps.spec.js
+++ b/test/unit/specs/util/defaultProps.spec.js
@@ -47,8 +47,8 @@ describe('defaultProps.js', () => {
       client: expect.any(Object),
       commit: expect.any(Object),
       env: expect.any(Object),
+      experience: expect.any(Object),
       items: expect.any(Object),
-      buttonStyle: expect.any(Object),
     }));
 
     expect(props.client).toEqual({
@@ -68,18 +68,13 @@ describe('defaultProps.js', () => {
       default: 'production',
     });
 
+    expect(props.experience).toEqual({
+      type: Object,
+      required: false,
+    });
+
     expect(props.items).toEqual({
       type: Array,
-      required: false,
-    });
-
-    expect(props.locale).toEqual({
-      type: String,
-      required: false,
-    });
-
-    expect(props.buttonStyle).toEqual({
-      type: Object,
       required: false,
     });
   });

--- a/test/unit/specs/util/paypalProp.spec.js
+++ b/test/unit/specs/util/paypalProp.spec.js
@@ -1,25 +1,37 @@
 import PayPalProp from '@/util/paypalProp';
 
 describe('paypalProp.js', () => {
-  it('construct with options object', () => {
-    const paypal = new PayPalProp({
-      name: 'some-name',
-      paypalName: 'somePaypal',
-      injectionType: 'someExperience',
+  describe('new paypalProp()', () => {
+    it('construct with most options specified', () => {
+      const paypal = new PayPalProp({
+        name: 'some-name',
+        paypalName: 'somePaypal',
+        injection: 'someExperience',
+      });
+
+      expect(paypal).toEqual(expect.objectContaining({
+        name: 'some-name',
+        propName: 'somePaypal',
+        injection: 'someExperience',
+      }));
     });
 
-    expect(paypal).toEqual(expect.objectContaining({
-      name: 'some-name',
-      propName: 'somePaypal',
-      injection: 'someExperience',
-    }));
+    it('construct with just name specified', () => {
+      const paypal = new PayPalProp({ name: 'some-name' });
+
+      expect(paypal).toEqual(expect.objectContaining({
+        name: 'some-name',
+        propName: 'some-name',
+        injection: 'button',
+      }));
+    });
   });
 
   it('getVmProp()', () => {
     const paypal = new PayPalProp({
       name: 'some-name',
       paypalName: 'somePaypal',
-      injectionType: 'someExperience',
+      injection: 'someExperience',
     });
 
     const prop = paypal.getVmProp();
@@ -34,7 +46,7 @@ describe('paypalProp.js', () => {
     const paypal = new PayPalProp({
       name: 'some-name',
       paypalName: 'somePaypal',
-      injectionType: 'someExperience',
+      injection: 'someExperience',
     });
 
     const o = {


### PR DESCRIPTION
Specifically fixes #16.

Turns out the prop validation for type got overwritten later on from `additionalProps.js`.