### PR TITLE
Emit payment-error event

### DIFF
--- a/examples/processing.html
+++ b/examples/processing.html
@@ -26,6 +26,7 @@
         v-on:payment-authorized="paymentAuthorized"
         v-on:payment-completed="paymentCompleted"
         v-on:payment-cancelled="paymentCancelled"
+        v-on:payment-error="paymentError"
         :client="paypal">
       </paypal-checkout>
     </div>
@@ -53,6 +54,9 @@
         paymentCancelled: function (data) {
           console.log(data);
         },
+        paymentError: function (err) {
+          console.error(err);
+        }
       },
     });
   </script>

--- a/src/components/PayPalCheckout.vue
+++ b/src/components/PayPalCheckout.vue
@@ -59,6 +59,10 @@ export default {
       const vue = this;
       vue.$emit('payment-cancelled', data);
     },
+    onError(err) {
+      const vue = this;
+      vue.$emit('payment-error', err);
+    },
   },
   mounted() {
     const vue = this;
@@ -82,6 +86,9 @@ export default {
 
       // Pass a function to be called when the customer cancels the payment
       onCancel: vue.onCancel,
+
+      // Pass a function to be called if an error occurs
+      onError: vue.onError,
     }, assignTo(vue, propTypes.BUTTON));
 
     paypal.Button.render(button, vue.$el);

--- a/test/unit/specs/components/PayPalCheckout.spec.js
+++ b/test/unit/specs/components/PayPalCheckout.spec.js
@@ -91,8 +91,8 @@ describe('PayPalCheckout.vue', () => {
       expect(div.is('div')).toBe(true);
     });
 
-    test('has zoid class', () => {
-      expect(checkout.contains('.zoid-visible')).toBe(true);
+    test('has xcomponent class', () => {
+      expect(checkout.contains('.xcomponent-visible')).toBe(true);
     });
 
     test('has same HTML structure', () => {


### PR DESCRIPTION
This simply ties into the onError event from `paypal-checkout`. Same general flow as `payment-cancelled` event implementation. I also reverted the zoid/xcomponent unit test (so all tests pass again) and left the rebuild out of this branch. I assume you will want to do that in your normal pre-release setup.

At minimum allows to catch if there were any errors in request. I have been able to catch a `DUPLICATE_TRANSACTION` error with it. Unfortunately the error object returned is very bare, but at least allows you to inform customers there was a problem with payment. Very surprised this wasn't already implemented.

Anyone needing to tie into this event right now, can install from secondary branch where I performed the full build as 3.2.1-rc1: https://github.com/Nicholi/vue-paypal-checkout/tree/beta_3.2.1
`npm install --save 'Nicholi/vue-paypal-checkout#beta_3.2.1'`